### PR TITLE
Prevent duplicates of the same PR

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -51,7 +51,18 @@ async function answerPrSubmission(queue, message, config) {
     return status.reason;
   }
 
-  await queue.push(status.metadata.url, message.user, message.channel, config.type);
+  const pushResult = await queue.push(
+    status.metadata.url,
+    message.user,
+    message.channel,
+    config.type
+  );
+
+  if (pushResult === false) {
+    return `${config.name} already in queue.`;
+  } else if (pushResult === null) {
+    return `${config.name} could not be added, sorry.`;
+  }
 
   const score = await queue.getScore(message.user, config.possibleTypes);
 

--- a/lib/postgres_locker.js
+++ b/lib/postgres_locker.js
@@ -17,8 +17,12 @@ module.exports.createLocker = dbClient => ({
       await dbClient.query(text, values);
       return true;
     } catch (err) {
-      logger.info('[locker] error', { msg: err.message, code: err.stack });
-      return false;
+      if (err.message && err.message.match(/^duplicate key.*$/ig)) {
+        logger.info('[locker] duplicate lock', { msg: err.message, user: message.user, ts: message.incoming_message.timestamp });
+        return false;
+      }
+      logger.error('[locker] error', { msg: err.message, code: err.stack });
+      throw err;
     }
   }
 });

--- a/lib/postgres_queue.js
+++ b/lib/postgres_queue.js
@@ -3,8 +3,10 @@ const logger = require('../utils/logger');
 module.exports.createQueue = dbClient => ({
   init: async () => {
     logger.info('[queue] init');
+    await dbClient.query('drop index if exists prs_channel_pr');
     await dbClient.query('drop table if exists prs');
-    await dbClient.query('create table if not exists prs ( id SERIAL PRIMARY KEY, pr text not null,reporter VARCHAR (100) not null,assigned VARCHAR (100) null default null,channel VARCHAR (100) not null,queued TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP);');
+    await dbClient.query('create table if not exists prs ( id SERIAL PRIMARY KEY,channel VARCHAR (100) not null, pr VARCHAR (100) not null,reporter VARCHAR (100) not null,assigned VARCHAR (100) null default null,queued TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP);');
+    await dbClient.query('create unique index if not exists prs_channel_pr on prs (channel,pr);');
   },
   push: async (pr, user = null, channel = null) => {
     try {
@@ -13,8 +15,14 @@ module.exports.createQueue = dbClient => ({
       // eslint-disable-next-line max-len
       const values = [pr, user, channel];
       await dbClient.query(text, values);
+      return true;
     } catch (err) {
+      if (err.message && err.message.match(/^duplicate key.*$/ig)) {
+        logger.info('[queue] duplicate PR', { msg: err.message, pr, user, channel });
+        return false;
+      }
       logger.error('[queue] push error', { msg: err.message, code: err.stack, pr, user, channel });
+      return null;
     }
   },
   remove: async pr => {

--- a/test/lib/bot.test.js
+++ b/test/lib/bot.test.js
@@ -46,7 +46,7 @@ describe('bot.js', () => {
             expect(url).to.eql('cannonical_url');
             expect(user).to.eql('me');
             expect(channel).to.eql('mychannel');
-            return Promise.resolve();
+            return Promise.resolve(true);
           },
           getScore: () => Promise.resolve(0.5)
         };
@@ -55,6 +55,40 @@ describe('bot.js', () => {
           channel: 'mychannel',
           text: 'pr <https://github.com/transcovo/logger/pull/3>'
         }, bot.PRCONFIG)).to.eql('PR in queue +1/-2. Your awesomeness score is 50%.');
+      });
+
+      it('should return a duplicate pr info if already there', async () => {
+        const queue = {
+          push: (url, user, channel) => {
+            expect(url).to.eql('cannonical_url');
+            expect(user).to.eql('me');
+            expect(channel).to.eql('mychannel');
+            return Promise.resolve(false);
+          },
+          getScore: () => Promise.resolve(0.5)
+        };
+        expect(await bot.answerPrSubmission(queue, {
+          user: 'me',
+          channel: 'mychannel',
+          text: 'pr <https://github.com/transcovo/logger/pull/3>'
+        }, bot.PRCONFIG)).to.eql('PR already in queue.');
+      });
+
+      it('should return an error message is some error is catched', async () => {
+        const queue = {
+          push: (url, user, channel) => {
+            expect(url).to.eql('cannonical_url');
+            expect(user).to.eql('me');
+            expect(channel).to.eql('mychannel');
+            return Promise.resolve(null);
+          },
+          getScore: () => Promise.resolve(0.5)
+        };
+        expect(await bot.answerPrSubmission(queue, {
+          user: 'me',
+          channel: 'mychannel',
+          text: 'pr <https://github.com/transcovo/logger/pull/3>'
+        }, bot.PRCONFIG)).to.eql('PR could not be added, sorry.');
       });
     });
   });

--- a/test/lib/postgres_queue.test.js
+++ b/test/lib/postgres_queue.test.js
@@ -165,6 +165,32 @@ describe('queue', () => {
       expect((await queue.pop('unknown', 'channelA')).pr).to.equal('AAA');
     });
 
+    it('should not add twice the same pr on a same channel', async() => {
+      const queue = queueFactory.createQueue(db);
+
+      await queue.push('AAA', 'joe', 'test');
+      const item = await queue.list();
+      expect(item).to.deep.equal([{
+        id: item[0].id,
+        assigned: null,
+        pr: 'AAA',
+        queued: item[0].queued,
+        reporter: 'joe',
+        channel: 'test'
+      }]);
+
+      await queue.push('AAA', 'jane', 'test');
+      const item2 = await queue.list();
+      expect(item2).to.deep.equal([{
+        id: item2[0].id,
+        assigned: null,
+        pr: 'AAA',
+        queued: item2[0].queued,
+        reporter: 'joe',
+        channel: 'test'
+      }]);
+    })
+
     it('should compute the score', async () => {
       const queue = queueFactory.createQueue(db);
 


### PR DESCRIPTION
Add a unique index on PR of a channel to prevent duplicate, and make sure the information is displayed as the bot answers